### PR TITLE
Add basic windows support without cygwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Installation
 
-`statcode` works on MacOS, Linux, and Windows (if you use Cygwin), with compiled binaries available for [every release](https://github.com/shobrook/statcode/releases). You can also install it with pip:
+`statcode` works on MacOS, Linux, and Windows, with compiled binaries available for [every release](https://github.com/shobrook/statcode/releases). You can also install it with pip:
 
 `$ pip install statcode`
 

--- a/statcode/statcode.py
+++ b/statcode/statcode.py
@@ -291,7 +291,13 @@ def main():
         content = generate_content(status_code)
 
         if content:
-            App(content) # Opens interface
+            try:
+                App(content) # Opens interface
+            except NameError:
+                size = os.get_terminal_size()
+                canvas = content.render(size)
+                text = "".join(text.decode("utf-8") for text in canvas.text)
+                print(text.rstrip())
         else:
             print(''.join([RED, "Sorry, statcode doesn't recognize: ", status_code, END]))
 


### PR DESCRIPTION
hello @shobrook 👋 !

This adds support for Windows without cygwin.

If the call to start urwid fails with a NameError. (i.e. `NameError: name 'fcntl' is not defined`) then the output will just be simple `print()` by rendering the `urwid.Padding`, and then printing the resulting `Canvas.text` 

![screenshot of statcode output in a windows cmd prompt](https://user-images.githubusercontent.com/13941027/42508555-d592ad4a-8440-11e8-997d-c654c5682b62.png)
