### PR TITLE
Fix CVE-2017-2809.

### DIFF
--- a/statcode/statcode.py
+++ b/statcode/statcode.py
@@ -15,8 +15,8 @@ try:
     CODE_DESCRIPTIONS = yaml.safe_load(
         open('/'.join([CURR_DIR, "code_descriptions.yml"]), 'r'))
 except yaml.constructor.ConstructorError as err:
-    print(str(err))
     print("Invalid file. Only support valid json and yaml files.")
+    sys.exit(1)
 
 # Scroll actions
 SCROLL_LINE_UP = "line up"

--- a/statcode/statcode.py
+++ b/statcode/statcode.py
@@ -11,7 +11,12 @@ from urwid.widget import BOX, FLOW, FIXED
 
 # List of status code descriptions
 CURR_DIR = os.path.dirname(os.path.realpath(__file__))
-CODE_DESCRIPTIONS = yaml.load(open('/'.join([CURR_DIR, "code_descriptions.yml"]), 'r'))
+try:
+    CODE_DESCRIPTIONS = yaml.safe_load(
+        open('/'.join([CURR_DIR, "code_descriptions.yml"]), 'r'))
+except yaml.constructor.ConstructorError as err:
+    print(str(err))
+    print("Invalid file. Only support valid json and yaml files.")
 
 # Scroll actions
 SCROLL_LINE_UP = "line up"


### PR DESCRIPTION
Yaml load is not safe you can inject code that will be interpreted by
this function.

this pull request resolve an [exploitable vulnerability (CVE-2017-2809)](https://nvd.nist.gov/vuln/detail/CVE-2017-2809) due to the usage of `yaml.load` instead of `yaml.safe_load`

Examples of usages of this vulnerability:
```shell
$ echo '!!python/object/apply:os.system ["echo powned; uname -a"]' > /path/to/code_descriptions.yml
$ statcode 404
powned
Linux vm 4.8.0-54-generic #57~16.04.1-Ubuntu SMP Wed May 24 16:22:28 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
```

Examples with the fix:
```shell
$ echo '!!python/object/apply:os.system ["echo powned; uname -a"]' > /path/to/code_descriptions.yml
$ statcode 404
could not determine a constructor for the tag 'tag:yaml.org,2002:python/object/apply:os.system'
  in "<unicode string>", line 1, column 1:
    !!python/object/apply:os.system  ...
    ^
Invalid file. Only support valid json and yaml files
```

Also we can only display an human readable message instead of the stack trace.