### PR TITLE
Add AUR installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,17 @@
 
 ## Installation
 
-`statcode` works on MacOS, Linux, and Windows, with compiled binaries available for [every release](https://github.com/shobrook/statcode/releases). You can also install it with pip:
+`statcode` works on MacOS, Linux, and Windows (if you use Cygwin), with compiled binaries available for [every release](https://github.com/shobrook/statcode/releases). You can also install it with pip:
 
-`$ pip install statcode`
+    $ pip install statcode
 
 Requires Python 3.0 or higher.
+
+### Arch Linux
+
+You can install the [`statcode`](https://aur.archlinux.org/packages/statcode/) package from the AUR:
+
+    $ aurman -S statcode
 
 ## Contributing
 


### PR DESCRIPTION
I added installation instructions for Arch Linux via the AUR to the README.